### PR TITLE
Adding missed `set -e` to bin/ commands

### DIFF
--- a/bin/gcm
+++ b/bin/gcm
@@ -1,4 +1,6 @@
 #!/bin/sh
+set -e
+
 echo "💣  `date +"%H:%M:%S"` [g]it [p]checkout [m]aster run start..."
 git checkout master
 echo "🏁  `date +"%H:%M:%S"` Done!"

--- a/bin/git-pwd
+++ b/bin/git-pwd
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 GIT=`which git`
 

--- a/bin/git-task
+++ b/bin/git-task
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -e
+
 GIT=/usr/bin/git
 GREP=/usr/bin/grep
 SED=/usr/bin/sed


### PR DESCRIPTION
This is a fix of #11 

Missed command was added in `gcm`, `git task` and `git pwd`.