### PR TITLE
Shell configuration split

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,14 @@ File structure:
   bin/ - useful CLI commands
   git/ - git configuration & aliases
     hooks/ - some git hook implementations
+  shell/ - shell configurations
 ```
 
-How to deploy:
+How to setup:
 
 ```shell
+git clone git@github.com:pryazhnikov/dotfiles.git .
+
 # Apply git configuration
 ./git/configure.sh
 
@@ -19,6 +22,19 @@ cp -rv git/hooks/* .git/
 
 # Copy cli commands into ~/bin/
 ./install.py
+
+# Apply shell configurations
+echo "# ZSH configuration" >> ~/.zshrc
+echo "_CONFIG_DIR='$(pwd)/shell'" >> ~/.zshrc
+echo ". \$_CONFIG_DIR/_common" >> ~/.zshrc
+echo ". \$_CONFIG_DIR/zshrc" >> ~/.zshrc
+
+echo "# Bash configuration" >> ~/.bashrc
+echo "_CONFIG_DIR='$(pwd)/shell'" >> ~/.bashrc
+echo ". \$_CONFIG_DIR/_common" >> ~/.bashrc
+echo ". \$_CONFIG_DIR/bashrc" >> ~/.bashrc
+
+chsh -s $(which zsh)
 ```
 
 ## CLI Commands (see [`bin/`](bin/))

--- a/shell/_common
+++ b/shell/_common
@@ -1,7 +1,3 @@
-# Check the window size after each command and, if necessary,
-# update the values of LINES and COLUMNS.
-shopt -s checkwinsize
-
 ###
 # Path configuration
 ###
@@ -10,22 +6,6 @@ if [ -d ~/bin ]; then
     #echo $PATH
 fi
 
-###
-# Helper functions
-###
-
-# "main" => " (main)"
-parse_git_branch() {
-    git branch --show-current 2>/dev/null \
-        | sed -e 's/^\(.*\)/ \(\1\)/'
-}
-
-###
-# Environments configuration
-###
-
-export PS1="\[\e[4;32m\]@\h \w/\$(parse_git_branch)\[\e[4;32m\]\$\[\e[0m\] "
-export PS2="\[\e[4;32m\] >\[\e[0m\] "
 export MYSQL_PS1='[\h] \d> '
 
 export EDITOR=vi
@@ -60,8 +40,8 @@ alias gti='git'
 
 # ls
 alias l.='ls -dFG .*'
-alias la='ls -lhAFG'
-alias ll='ls -lhFG'
+alias la='ls -lhAFG' # List + hidden files + file types + colors
+alias ll='ls -lhFG' # List + file types + colors
 
 # mysql
 alias my='mysql -A'
@@ -76,12 +56,3 @@ alias df='df -ih'
 alias du='du -h'
 alias tf='tail -F'
 alias wl='wc -l'
-
-###
-# Unversioned configuration
-# It should be placed at the end of file to make it possible to override everything
-###
-if [ -f ~/.bashrc_local ]; then
-    #echo "Reading local bashrc config"
-    source ~/.bashrc_local
-fi

--- a/shell/bashrc
+++ b/shell/bashrc
@@ -1,0 +1,32 @@
+# Check the window size after each command and, if necessary,
+# update the values of LINES and COLUMNS.
+shopt -s checkwinsize
+
+###
+# Helper functions
+###
+
+# "main" => " (main)"
+parse_git_branch() {
+    git branch --show-current 2>/dev/null \
+        | sed -e 's/^\(.*\)/ \(\1\)/'
+}
+
+###
+# Environments configuration
+###
+
+export PS1="\[\e[4;32m\]@\h \w/\$(parse_git_branch)\[\e[4;32m\]\$\[\e[0m\] "
+export PS2="\[\e[4;32m\] >\[\e[0m\] "
+
+# Config reloading (shell specific alias)
+alias reload='. ~/.bashrc'
+
+###
+# Unversioned configuration
+# It should be placed at the end of file to make it possible to override everything
+###
+if [ -f ~/.bashrc_local ]; then
+    #echo "Reading local bashrc config"
+    source ~/.bashrc_local
+fi

--- a/shell/zshrc
+++ b/shell/zshrc
@@ -1,0 +1,22 @@
+# Prompt configuration
+
+# Config reloading (shell specific alias)
+alias reload='. ~/.zshrc'
+
+# Git branch
+# See: https://github.com/git/git/blob/master/contrib/completion/git-prompt.sh
+source ~/.git-prompt.sh
+
+# Colored output
+# See: https://stackoverflow.com/questions/689765/how-can-i-change-the-color-of-my-prompt-in-zsh-different-from-normal-text
+autoload -U colors && colors
+PS1="%{$fg[green]%}@%M %B%{$fg[magenta]%}%~%b$(__git_ps1 " (%s)")%{$fg[green]%}%B$%{$reset_color%}%b "
+PS2=" %{$fg[green]%}%B>%b%{$reset_color%} "
+
+# Shell completion
+autoload -Uz compinit && compinit
+
+# To restore the emacs keymap (instead of vi)
+# Required for navigation
+# See: https://defkey.com/zsh-z-shell-shortcuts#google_vignette
+bindkey -e


### PR DESCRIPTION
Idea:

Current version contains bash shell configuration only.
This pull request is about adding zsh configuration too.

Implementation:

* Configuration is moved into `shell/` directory
* The only configuration file is split into two (`_common` and `bashrc`). Both are used to configure bash
* `zshrc` file was added for zsh specific configuration
* README is updated to simplify configuration setting process
