### PR TITLE
Default branch fix

### DIFF
--- a/bin/git-default-branch
+++ b/bin/git-default-branch
@@ -31,9 +31,11 @@ return_branch_if_exists() {
 ### Logic start
 
 # Getting from configuration (git 2.28+)
-config_branch=`$GIT config --get init.defaultBranch`
+config_branch=`$GIT config --get --local init.defaultBranch`
 if [[ "$config_branch" != "" ]]; then
     return_branch_if_exists "$config_branch"
+
+    fatal_error "Local defaultBranch ($config_branch) id not found, please fix it!"
 fi
 
 # No explicit value, so trying to find something from possible values
@@ -41,4 +43,4 @@ for branch in $POSSIBLE_DEFAULT_BRANCHES; do
     return_branch_if_exists "$branch"
 done
 
-fatal_error "No default branch found (init.defaultBranch: $config_branch, checked options: $POSSIBLE_DEFAULT_BRANCHES)"
+fatal_error "No default branch found (checked options: $POSSIBLE_DEFAULT_BRANCHES)"

--- a/bin/git-default-branch
+++ b/bin/git-default-branch
@@ -4,23 +4,41 @@
 # * `git config --get` returns an error in case of missing value
 # * `git show-ref` return an error in case of missing branch
 
+GIT=`which git`
 POSSIBLE_DEFAULT_BRANCHES="main master"
 
-# Getting from configuration (git 2.28+)
-config_branch=`git config --get init.defaultBranch`
-if [[ "$config_branch" != "" ]]; then
-    echo $config_branch
-    exit 0
-fi
+### Helper functions
 
-# No explicit value, so trying to find something from possible values
-for branch in $POSSIBLE_DEFAULT_BRANCHES; do
-    branch_hash=`git show-ref $branch`
+fatal_error() {
+    local message="$1"
+    >&2 echo "❌ $message"
+    exit 1
+}
+
+return_branch_if_exists() {
+    local branch="$1"
+    if [ "$branch" == "" ]; then
+        fatal_error "Empty branch name was given as an argument! Please fix it"
+    fi
+
+    branch_hash=`$GIT show-ref $branch`
     if [ "$branch_hash" != "" ]; then
         echo $branch
         exit 0
     fi
+}
+
+### Logic start
+
+# Getting from configuration (git 2.28+)
+config_branch=`$GIT config --get init.defaultBranch`
+if [[ "$config_branch" != "" ]]; then
+    return_branch_if_exists "$config_branch"
+fi
+
+# No explicit value, so trying to find something from possible values
+for branch in $POSSIBLE_DEFAULT_BRANCHES; do
+    return_branch_if_exists "$branch"
 done
 
->&2 echo "❌ No default branch found"
-exit 1
+fatal_error "No default branch found (init.defaultBranch: $config_branch, checked options: $POSSIBLE_DEFAULT_BRANCHES)"


### PR DESCRIPTION
The implementation of #23

The logic of the fixed version:
* it ignores global `init.defaultBranch` config param and tries to guess the branch name
* it ignores local `init.defaultBranch` config param and fails in case of missing param (aka fail fast)

It should work fine by default, but respect repo specific settings. Looks like the easiest way to fix the problem


