### PR TITLE
Improvements of git-pwd comamnd

### DIFF
--- a/bin/git-pwd
+++ b/bin/git-pwd
@@ -3,12 +3,16 @@ set -e
 
 GIT=`which git`
 
-GIT_BRANCH=`$GIT name-rev --name-only HEAD`
+GIT_USER=`$GIT config --get user.name`
+GIT_EMAIL=`$GIT config --get user.email`
+GIT_BRANCH=`$GIT branch --show-current`
 GIT_ORIGIN_URL=`$GIT config --get remote.origin.url`
 JIRA_CODE=`echo $GIT_BRANCH | sed -e 's/_[a-zA-Z0-9_]*//'`
 # SERVER-99999_comp => SERVER-99999
 # QATASKS-777_no_more_getUpdateLocation => QATASKS-777
 
+echo "👤  User:      $GIT_USER"
+echo "📫  E-mail:    $GIT_EMAIL"
 echo "📋  Branch:    $GIT_BRANCH"
 echo "📦  Origin:    $GIT_ORIGIN_URL"
 

--- a/bin/git-pwd
+++ b/bin/git-pwd
@@ -31,8 +31,9 @@ if [[ "$GIT_ORIGIN_URL" == *"git@bitbucket.org"* ]]; then
 fi
 
 # Private URL (JIRA issue)
-if [[ "$GIT_BRANCH" == "master" ]]; then
-    # Master is a default branch. JIRA issue is not expected
+GIT_DEFAULT_BRANCH=`$GIT default-branch`
+if [[ "$GIT_BRANCH" == "$GIT_DEFAULT_BRANCH" ]]; then
+    # JIRA issue is not expected for this branch
     exit
 fi
 


### PR DESCRIPTION
The changes:
* Adding of user name and email (see issue #25)
* Fix of branch name to resolve an incorrect result after switching into a new branch (without branch specific commits)
* Using `git default-branch` instead of a hardcoded `master` branch