### PR TITLE
git diff-index for uncommited changes tracking

### DIFF
--- a/bin/git-seamless-pull
+++ b/bin/git-seamless-pull
@@ -15,7 +15,7 @@ if [ "$BRANCH_NAME" == "" ]; then
 fi
 
 stash_was_called=0
-if [ -n "$(git status --porcelain)" ]; then
+if [ -n "$(git diff-index HEAD)" ]; then
     echo "⌛️  `date +"%H:%M:%S"` There are uncommitted changes in the working directory. Stash call is required..."
     git stash
     stash_was_called=1


### PR DESCRIPTION
Solves #31 

The idea is to stop checking the overall difference, but use tracked files only. `git diff-index` seems to be the best option for that.